### PR TITLE
Add optional GPU support for Linux

### DIFF
--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -15,9 +15,10 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
 ]
 dependencies=[
-    "onnxruntime",
-    "tqdm",
-    "gemmi"
+    'onnxruntime-gpu; platform_system != "Darwin"',
+    'onnxruntime; platform_system == "Darwin"',
+    'tqdm',
+    'gemmi'
 ]
 [project.urls]
 Homepage = "https://github.com/Dialpuri/NucleoFind"

--- a/package/src/nucleofind/predict.py
+++ b/package/src/nucleofind/predict.py
@@ -83,7 +83,7 @@ class Prediction:
 
     def save_variance_map(self, output_path: str):
         if not self.compute_variance:
-            logging.warn("Attempting to output a variance map without specifying compute_variance=True")
+            logging.warning("Attempting to output a variance map without specifying compute_variance=True")
             return
         ccp4 = gemmi.Ccp4Map()
         ccp4.grid = self.variance_grid
@@ -418,7 +418,7 @@ def model_not_found_err():
     print("""
             No models have been found in either site_packages or CCP4/lib/data.
             You can install models using the command:
-            nucleofind-install -o site_packages -m phos
+            nucleofind-install -m phosphate
         """)
 
 

--- a/package/src/nucleofind/predict.py
+++ b/package/src/nucleofind/predict.py
@@ -20,7 +20,7 @@ class Prediction:
     def __init__(self, model_dir: str, use_gpu: bool = False, compute_variance: bool = False):
         self.model_dir: str = model_dir
         self.use_gpu: bool = use_gpu
-        print(platform.system())
+
         if use_gpu and platform.system() == "Darwin":
             logging.warning("GPU acceleration was specified but is not supported on MacOS, continuing with CPU only")
             self.use_gpu = False
@@ -54,7 +54,7 @@ class Prediction:
         try:
             self._load_model()
         except OSError:
-            print(
+            logging.critical(
                 "This model is corrupted, perhaps due to an incomplete download. Try downloading it again with "
                 "nucleofind-install -m TYPE --reinstall")
             sys.exit()
@@ -403,7 +403,7 @@ def run():
             f"Input file has not been found, check path\nPath Supplied {args['i']} from {os.getcwd()}")
 
     if args["raw"] and args["variance"]:
-        logging.info(
+        logging.warning(
             f"Supplying both raw and variance flags does not output a raw variance map, just the variance map.")
 
     prediction = Prediction(model_dir=model_path, 
@@ -420,7 +420,7 @@ def run():
 
     end = time.time()
 
-    print(f"Time taken {end - start:.2f} seconds / {(end - start) / 60:.2f} minutes")
+    logging.info(f"Time taken {end - start:.2f} seconds / {(end - start) / 60:.2f} minutes")
 
 
 def model_not_found_err():

--- a/package/src/nucleofind/predict.py
+++ b/package/src/nucleofind/predict.py
@@ -1,22 +1,30 @@
+import argparse
 import logging
 import os
-from typing import List
-import onnxruntime as rt
-import numpy as np
-import gemmi
-from tqdm import tqdm
-import time
-import argparse
 import site
-from glob import glob
 import sys
+import time
+from glob import glob
+from typing import List
+import platform
+
+import gemmi
+import numpy as np
+import onnxruntime as rt
+from tqdm import tqdm
+
 from .__version__ import __version__
 
 
 class Prediction:
-    def __init__(self, model_dir: str,  use_gpu: bool = False, compute_variance: bool = False):
+    def __init__(self, model_dir: str, use_gpu: bool = False, compute_variance: bool = False):
         self.model_dir: str = model_dir
         self.use_gpu: bool = use_gpu
+        print(platform.system())
+        if use_gpu and platform.system() == "Darwin":
+            logging.warning("GPU acceleration was specified but is not supported on MacOS, continuing with CPU only")
+            self.use_gpu = False
+
         self.compute_variance: bool = compute_variance
         self.model_name: str = model_dir.split("/")[-1]
 
@@ -47,7 +55,8 @@ class Prediction:
             self._load_model()
         except OSError:
             print(
-                "This model is corrupted, perhaps due to an incomplete download. Try downloading it again with nucleofind-install -m TYPE --reinstall")
+                "This model is corrupted, perhaps due to an incomplete download. Try downloading it again with "
+                "nucleofind-install -m TYPE --reinstall")
             sys.exit()
 
         if column_labels == [None, None]:
@@ -369,7 +378,7 @@ def run():
     parser.add_argument("-v", "--version", action="version", version=__version__)
     args = vars(parser.parse_args())
 
-    log_level = logging.CRITICAL
+    log_level = logging.WARNING
     if args["debug"]:
         log_level = logging.DEBUG
 


### PR DESCRIPTION
## Description

This PR adds optional GPU support for linux by using the `onnxruntime-gpu` package on Linux and `onnxruntime` on MacOS. Additionally, bugs with computing variance were fixed.