### PR TITLE
Add option to run slow tests

### DIFF
--- a/package/tests/conftest.py
+++ b/package/tests/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runslow", action="store_true", default=False, help="run slow tests"
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)

--- a/package/tests/test_install.py
+++ b/package/tests/test_install.py
@@ -2,7 +2,7 @@ import subprocess
 import site
 import os
 import hashlib
-
+import pytest
 
 def get_md5_sums():
     phosphate_md5_sum = "61c0f43b46ff9a686f23c63b4bac0583"
@@ -43,6 +43,7 @@ def perform_installation_test(model_type: str):
     assert found_sum == data[model_type]
 
 
+@pytest.mark.slow
 def test_install():
     perform_installation_test("phosphate")
     perform_installation_test("sugar")


### PR DESCRIPTION
This commit introduces a new option in pytest to allow running of slow tests. By default, the slow tests are skipped unless the "--runslow" flag is provided. This feature improves testing flexibility and efficiency.