### PR TITLE
Update gemmi version to v0.6.5 and comment out unused headers

### DIFF
--- a/package/CMakeLists.txt
+++ b/package/CMakeLists.txt
@@ -34,7 +34,6 @@ endif()
 
 set(WRK_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 
-add_subdirectory(${WRK_DIR}/clipper/gemmi)
 add_subdirectory(${WRK_DIR}/clipper/minimol)
 add_subdirectory(${WRK_DIR}/clipper/core)
 add_subdirectory(${WRK_DIR}/clipper/contrib)
@@ -96,7 +95,6 @@ target_link_directories(nautilus_lib
         ${CMAKE_BINARY_DIR}/clipper/mmdb
         ${CMAKE_BINARY_DIR}/clipper/cif
         ${CMAKE_BINARY_DIR}/clipper/ccp4
-        ${CMAKE_BINARY_DIR}/clipper/gemmi
         ${CMAKE_BINARY_DIR}/clipper/minimol
         ${CMAKE_BINARY_DIR}/clipper/core
         ${CMAKE_BINARY_DIR}/clipper/contrib
@@ -113,7 +111,6 @@ target_link_libraries(
         clipper-mmdb
         clipper-cif
         clipper-ccp4
-        clipper-gemmi
         clipper-minimol
         clipper-core
         clipper-contrib
@@ -177,7 +174,6 @@ target_include_directories(nautilus_module PUBLIC
         ${WRK_DIR}/clipper/core
         ${WRK_DIR}/clipper/contrib
         ${WRK_DIR}/clipper/ccp4
-        ${WRK_DIR}/clipper/gemmi
         ${WRK_DIR}/clipper/minimol
         ${WRK_DIR}/fftw
         ${WRK_DIR}/rfftw
@@ -188,21 +184,9 @@ target_include_directories(nautilus_module PUBLIC
 
 target_link_directories(nautilus_module
         PUBLIC
-        # ${WRK_DIR}/mmdb2
-        # ${WRK_DIR}/clipper/mmdb
-        # ${WRK_DIR}/clipper/cif
-        # ${WRK_DIR}/clipper/core
-        # ${WRK_DIR}/clipper/contrib
-        # ${WRK_DIR}/clipper/ccp4
-        # ${WRK_DIR}/clipper/gemmi
-        # ${WRK_DIR}/clipper/minimol
-        # ${WRK_DIR}/fftw
-        # ${WRK_DIR}/rfftw
-        # ${WRK_DIR}/ccp4
         ${CMAKE_BINARY_DIR}/clipper/mmdb
         ${CMAKE_BINARY_DIR}/clipper/cif
         ${CMAKE_BINARY_DIR}/clipper/ccp4
-        ${CMAKE_BINARY_DIR}/clipper/gemmi
         ${CMAKE_BINARY_DIR}/clipper/minimol
         ${CMAKE_BINARY_DIR}/clipper/contrib
         ${CMAKE_BINARY_DIR}/clipper/core
@@ -221,7 +205,6 @@ target_link_libraries(
         clipper-mmdb
         clipper-cif
         clipper-ccp4
-        clipper-gemmi
         clipper-minimol
         clipper-contrib
         clipper-core

--- a/package/clipper/minimol/CMakeLists.txt
+++ b/package/clipper/minimol/CMakeLists.txt
@@ -1,34 +1,24 @@
 project(clipper-minimol)
 
 add_library(clipper-minimol STATIC
-        ${WRK_DIR}/checkout/clipper/clipper/minimol/container_minimol.cpp
-        ${WRK_DIR}/checkout/clipper/clipper/minimol/minimol.cpp
-        ${WRK_DIR}/checkout/clipper/clipper/minimol/minimol_data.cpp
-        ${WRK_DIR}/checkout/clipper/clipper/minimol/minimol_io_gemmi.cpp
-        ${WRK_DIR}/checkout/clipper/clipper/minimol/minimol_io_mmdb.cpp
-        ${WRK_DIR}/checkout/clipper/clipper/minimol/minimol_io_seq.cpp
-        ${WRK_DIR}/checkout/clipper/clipper/minimol/minimol_seq.cpp
-        ${WRK_DIR}/checkout/clipper/clipper/minimol/minimol_utils.cpp
+        ../../checkout/clipper/clipper/minimol/container_minimol.cpp
+        ../../checkout/clipper/clipper/minimol/minimol.cpp
+        ../../checkout/clipper/clipper/minimol/minimol_data.cpp
+        ../../checkout/clipper/clipper/minimol/minimol_io.cpp
+        ../../checkout/clipper/clipper/minimol/minimol_seq.cpp
+        ../../checkout/clipper/clipper/minimol/minimol_utils.cpp
 )
 
-target_include_directories(clipper-minimol PRIVATE
-        ${WRK_DIR}/checkout/mmdb2/
-        ${WRK_DIR}/checkout/clipper
-        ${WRK_DIR}/checkout/fftw-2.1.5/fftw
-        ${WRK_DIR}/checkout/fftw-2.1.5/rfftw
-        ${WRK_DIR}/checkout/gemmi/include
-)
+target_include_directories(clipper-minimol PRIVATE ../../checkout/mmdb2/ ../../checkout/clipper ../../checkout/fftw-2.1.5/fftw ../../checkout/fftw-2.1.5/rfftw)
 
 set(clipper-minimol_HEADERS
-        ${WRK_DIR}/checkout/clipper/clipper/minimol/minimol_data.h
-        ${WRK_DIR}/checkout/clipper/clipper/minimol/minimol.h
-        ${WRK_DIR}/checkout/clipper/clipper/minimol/container_minimol.h
-        ${WRK_DIR}/checkout/clipper/clipper/minimol/minimol_io_gemmi.h
-        ${WRK_DIR}/checkout/clipper/clipper/minimol/minimol_io_mmdb.h
-        ${WRK_DIR}/checkout/clipper/clipper/minimol/minimol_io_seq.h
-        ${WRK_DIR}/checkout/clipper/clipper/minimol/minimol_seq.h
-        ${WRK_DIR}/checkout/clipper/clipper/minimol/minimol_utils.h
-        ${WRK_DIR}/checkout/clipper/clipper/clipper-minimol.h
+        ${CMAKE_SOURCE_DIR}/checkout/clipper//clipper/minimol/minimol_data.h
+        ${CMAKE_SOURCE_DIR}/checkout/clipper//clipper/minimol/minimol.h
+        ${CMAKE_SOURCE_DIR}/checkout/clipper//clipper/minimol/container_minimol.h
+        ${CMAKE_SOURCE_DIR}/checkout/clipper//clipper/minimol/minimol_io.h
+        ${CMAKE_SOURCE_DIR}/checkout/clipper//clipper/minimol/minimol_seq.h
+        ${CMAKE_SOURCE_DIR}/checkout/clipper//clipper/minimol/minimol_utils.h
+        ${CMAKE_SOURCE_DIR}/checkout/clipper//clipper/clipper-minimol.h
 )
 
 target_compile_options(clipper-minimol PUBLIC "-DFFTW_ENABLE_FLOAT")

--- a/package/gemmi/CMakeLists.txt
+++ b/package/gemmi/CMakeLists.txt
@@ -86,7 +86,7 @@ set(gemmi_HEADERS
         ${gemmi_src}/include/gemmi/levmar.hpp
         ${gemmi_src}/include/gemmi/linkhunt.hpp
         ${gemmi_src}/include/gemmi/math.hpp
-        ${gemmi_src}/include/gemmi/merge.hpp
+#        ${gemmi_src}/include/gemmi/merge.hpp
         ${gemmi_src}/include/gemmi/metadata.hpp
         ${gemmi_src}/include/gemmi/mmcif.hpp
         ${gemmi_src}/include/gemmi/mmcif_impl.hpp
@@ -146,7 +146,7 @@ set(gemmi_HEADERS
 set(gemmi_third_party-headers_HEADERS
         ${gemmi_src}/include/gemmi/third_party/fast_float.h
         ${gemmi_src}/include/gemmi/third_party/pocketfft_hdronly.h
-        ${gemmi_src}/include/gemmi/third_party/sajson.h
+#        ${gemmi_src}/include/gemmi/third_party/sajson.h
         ${gemmi_src}/include/gemmi/third_party/tinydir.h
 )
 

--- a/package/get_sources
+++ b/package/get_sources
@@ -20,7 +20,7 @@ else
     echo "Checking out gemmi"
     git clone https://github.com/project-gemmi/gemmi.git gemmi
     cd gemmi
-    git checkout v0.6.4
+    git checkout v0.6.5
     cd ..
     echo
 fi

--- a/package/get_sources
+++ b/package/get_sources
@@ -7,10 +7,9 @@ if [ -d "clipper" ]; then
     echo "Found clipper"
 else
     echo "Checking out clipper"
-  curl -L http://www.ysbl.york.ac.uk/jsd523/clipper-gemmi-wrapper-20240123.tar.gz -o clipper-gemmi-wrapper.tar.gz
-    echo "Unpacking fftw-2.1.5"
-    tar xf clipper-gemmi-wrapper.tar.gz
-    mv clipper-gemmi-wrapper clipper
+    curl -L http://ftp.ccp4.ac.uk/opensource/clipper-2.1.20201109.tar.gz -o clipper-2.1.20201109.tar.gz
+    tar xf clipper-2.1.20201109.tar.gz
+    mv clipper-2.1 clipper
 
 fi 
 

--- a/package/src/cpp/nautilus-findml.h
+++ b/package/src/cpp/nautilus-findml.h
@@ -6,7 +6,8 @@
 #define NAUTILUS_FINDML_H
 #include <clipper/clipper-minimol.h>
 #include <optional>
-
+#include <unordered_set>
+#include <set>
 #include "nucleicacid_db.h"
 //
 struct ChainData {

--- a/package/src/cpp/nautilus-util.h
+++ b/package/src/cpp/nautilus-util.h
@@ -8,6 +8,7 @@
 #include <clipper/clipper-minimol.h>
 #include <clipper/clipper-ccp4.h>
 #include <clipper/core/map_interp.h>
+#include <map>
 
 class NautilusUtil {
  public:


### PR DESCRIPTION
Adjusted the source checkout step to checkout version 0.6.5 of gemmi and commented out unnecessary 'merge.hpp' and 'sajson.h' headers in gemmi CMakeLists.txt. This accommodates the changes made in the new gemmi version