### PR TITLE
Added clipper-ccp4 library to NucleoFind

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -48,7 +48,9 @@ jobs:
         run: pip install pytest
 
       - name: Install NucleoFind models
-        run:  nucleofind-install --all
+        run: |
+          nucleofind-install -m core
+          nucleofind-install -m nano
 
       - name: Run tests
         run : pytest tests

--- a/docs/Writerside/writerside.cfg
+++ b/docs/Writerside/writerside.cfg
@@ -6,5 +6,5 @@
     <images dir="images" web-path="images"/>
     <categories src="c.list"/>
     <vars src="v.list"/>
-    <instance src="n.tree" web-path="/n/" version="1.2.0"/>
+    <instance src="n.tree" web-path="/n/" version="1.2.1"/>
 </ihp>

--- a/package/clipper/ccp4/CMakeLists.txt
+++ b/package/clipper/ccp4/CMakeLists.txt
@@ -7,4 +7,20 @@ ${WRK_DIR}/checkout/clipper/clipper/ccp4/ccp4_mtz_types.cpp
 ${WRK_DIR}/checkout/clipper/clipper/ccp4/ccp4_utils.cpp
 )
 
-target_include_directories(clipper-ccp4 PRIVATE ${WRK_DIR}/checkout/libccp4 ${WRK_DIR}/checkout/clipper ${WRK_DIR}/fftw ${WRK_DIR}/rfftw)
+target_include_directories(clipper-ccp4 PRIVATE ${WRK_DIR}/checkout/libccp4
+        ${WRK_DIR}/checkout/clipper ${WRK_DIR}/fftw ${WRK_DIR}/rfftw)
+
+set(clipper-ccp4_HEADERS
+    ${WRK_DIR}/checkout/clipper/clipper/ccp4/ccp4_map_io.h
+    ${WRK_DIR}/checkout/clipper/clipper/ccp4/ccp4_mtz_io.h
+    ${WRK_DIR}/checkout/clipper/clipper/ccp4/ccp4_mtz_types.h
+    ${WRK_DIR}/checkout/clipper/clipper/ccp4/ccp4_utils.h
+)
+
+set_target_properties(clipper-ccp4 PROPERTIES PUBLIC_HEADER "${clipper-ccp4_HEADERS}")
+
+install(TARGETS clipper-ccp4
+        LIBRARY DESTINATION lib
+        PUBLIC_HEADER DESTINATION include/clipper/ccp4
+)
+

--- a/package/src/nucleofind/__version__.py
+++ b/package/src/nucleofind/__version__.py
@@ -1,3 +1,3 @@
 #  Copyright (c) 2024 Jordan Dialpuri, Jon Agirre, Kathryn Cowtan, Paul Bond and University of York. All rights reserved
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"


### PR DESCRIPTION
### Description

This PR adds the clipper-ccp4 library to the build for use in projects depending on NucleoFind.