### PR TITLE
Reduce Python required version from 3.10 to 3.9

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -23,8 +23,9 @@ env:
 
 jobs:
   build:
+    if: github.event.release.prerelease == false
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -45,6 +46,7 @@ jobs:
           retention-days: 7
 
   deploy:
+    if: github.event.release.prerelease == false
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -145,7 +145,6 @@ jobs:
     if: github.event.release.prerelease == false
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
     - uses: actions/setup-python@v5

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   check_versioning:
     name: Check versions match
+    if: github.event.release.prerelease == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -24,6 +25,7 @@ jobs:
 
   run_tests:
     name: Run Python tests
+    if: github.event.release.prerelease == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -63,6 +65,7 @@ jobs:
   build_sdist:
     needs: [ check_versioning, run_tests ]
     name: Build SDist
+    if: github.event.release.prerelease == false
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -139,6 +142,7 @@ jobs:
 
   upload_all:
     name: Upload if release
+    if: github.event.release.prerelease == false
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.9'
       - run: |
           cd package
           mkdir checkout
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.9'
       - name: Install Clang
         run: sudo apt-get install -y clang
 

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.9'
 
       - name: Install Clang
         run: |
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.9'
 
       - uses: TheMrMilchmann/setup-msvc-dev@v3
         with:

--- a/docs/Writerside/cfg/buildprofiles.xml
+++ b/docs/Writerside/cfg/buildprofiles.xml
@@ -8,7 +8,7 @@
     </variables>
     <build-profile instance="instance_id"/>
     <footer>
-        <copyright>Jordan Dialpuri | University of York 2023 - 2025</copyright>
+        <copyright>Jordan Dialpuri | University of York 2023 - 2026</copyright>
         <social type="email" href="jordan.dialpuri@york.ac.uk"/>
     </footer>
 </buildprofiles>

--- a/docs/Writerside/n.tree
+++ b/docs/Writerside/n.tree
@@ -7,10 +7,16 @@
                  start-page="About-NucleoFind.topic">
 
     <toc-element topic="About-NucleoFind.topic"/>
-    <toc-element topic="Installation.topic"/>
-    <toc-element topic="ModelInstallation.topic"/>
-    <toc-element topic="Command-Line-Usage.topic"/>
-    <toc-element topic="Python-Usage.topic"/>
+    <toc-element toc-title="Installation">
+        <toc-element topic="ModelInstallation.topic"/>
+        <toc-element topic="Installation.topic"/>
+    </toc-element>
+    <toc-element toc-title="Usage - Predictions" >
+        <toc-element topic="Command-Line-Usage.topic"/>
+        <toc-element topic="Python-Usage.topic"/>
+    </toc-element>
+    <toc-element toc-title="Usage - Building">
+        <toc-element topic="Model-Building.topic"/>
+    </toc-element>
     <toc-element topic="Model-Cleanup.topic"/>
-    <toc-element topic="Model-Building.topic"/>
 </instance-profile>

--- a/docs/Writerside/topics/Command-Line-Usage.topic
+++ b/docs/Writerside/topics/Command-Line-Usage.topic
@@ -75,10 +75,9 @@
                 Column name of structure factor phases.
                 <p>Default: PHWT</p>
             </def>
-             <def title="--use-symmetry">
-                <p>Predict over the entire unit cell instead of the asymmetric unit</p>
-                 <p>Default: False</p>
-                <b>Advanced</b>
+             <def title="--use-asu-only">
+                <p>Predict over the asymmetric unit only. </p><p>This is faster, but depending on the spacegroup,
+                 may produce worse predictions.</p>
             </def>
 <!--            <def title="-raw">-->
 <!--                <p>Use raw predicted values to form the output map.</p>-->

--- a/docs/Writerside/topics/Model-Cleanup.topic
+++ b/docs/Writerside/topics/Model-Cleanup.topic
@@ -6,7 +6,7 @@
        title="Model Cleanup" id="Model-Cleanup">
 
     <p>
-        NucleoFind uses a set of pre-trained machine learning models to predict where phosphate, sugar and base
+        NucleoFind uses a pre-trained machine learning model to predict where phosphate, sugar and base
         positions could be in an electron density map. If you want to delete the NucleoFind models you can use this tool.
     </p>
 

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -7,7 +7,7 @@ name = "nucleofind"
 dynamic = ["version"]
 description = "NucleoFind: A Deep-Learning Network for Interpreting Nucleic Acid Electron Density"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 authors = [
     { name = "Jordan Dialpuri", email = "jordan.dialpuri@york.ac.uk" },
 ]

--- a/package/src/nucleofind/build.py
+++ b/package/src/nucleofind/build.py
@@ -1,11 +1,11 @@
 #  Copyright (c) 2024 Jordan Dialpuri, Jon Agirre, Kathryn Cowtan, Paul Bond and University of York. All rights reserved
 
 import dataclasses
-import pathlib
+from pathlib import Path
 import site
 import traceback
 from importlib.metadata import PackageNotFoundError
-
+from typing import Union
 
 from .nautilus_module import Input, Output, run
 import argparse
@@ -15,16 +15,16 @@ from .prediction.predict import predict_map
 
 @dataclasses.dataclass
 class InputParameters:
-    mtzin: str | pathlib.Path = ""
-    pdbin: str | pathlib.Path = ""
-    seqin: str | pathlib.Path = ""
-    phosin: str | pathlib.Path = ""
-    sugarin: str | pathlib.Path = ""
-    basein: str | pathlib.Path = ""
-    colinfo: str | pathlib.Path = ""
-    colinphifom: str | pathlib.Path = ""
-    colinfc: str | pathlib.Path = ""
-    colinfree: str | pathlib.Path = ""
+    mtzin: Union[Path, str] = ""
+    pdbin: Union[Path, str] = ""
+    seqin: Union[Path, str] = ""
+    phosin: Union[Path, str] = ""
+    sugarin: Union[Path, str] = ""
+    basein: Union[Path, str] = ""
+    colinfo: Union[Path, str] = ""
+    colinphifom: Union[Path, str] = ""
+    colinfc: Union[Path, str] = ""
+    colinfree: Union[Path, str] = ""
     em: bool = False
     cycles: int = 3
     remove_clashing_protein: bool = True
@@ -32,13 +32,13 @@ class InputParameters:
 
 @dataclasses.dataclass
 class OutputParameters:
-    pdbout: str | pathlib.Path = ""
-    xmlout: str | pathlib.Path = ""
+    pdbout: Union[Path, str] = ""
+    xmlout: Union[Path, str] = ""
 
 
 def find_database() -> str:
     for pkg in site.getsitepackages():
-        database_path = pathlib.Path(pkg) / "nucleofind_models" / "nucleofind-database.cif"
+        database_path = Path(pkg) / "nucleofind_models" / "nucleofind-database.cif"
         if database_path.exists():
             return str(database_path)
     return ""

--- a/package/src/nucleofind/build.py
+++ b/package/src/nucleofind/build.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import site
 import traceback
 from importlib.metadata import PackageNotFoundError
-
+from typing import Union
 
 from .nautilus_module import Input, Output, run
 import argparse
@@ -16,16 +16,16 @@ from .prediction.predict import predict_map
 
 @dataclasses.dataclass
 class InputParameters:
-    mtzin: str | Path = ""
-    pdbin: str | Path = ""
-    seqin: str | Path = ""
-    phosin: str | Path = ""
-    sugarin: str | Path = ""
-    basein: str | Path = ""
-    colinfo: str | Path = ""
-    colinphifom: str | Path = ""
-    colinfc: str | Path = ""
-    colinfree: str | Path = ""
+    mtzin: Union[Path, str] = ""
+    pdbin: Union[Path, str] = ""
+    seqin: Union[Path, str] = ""
+    phosin: Union[Path, str] = ""
+    sugarin: Union[Path, str] = ""
+    basein: Union[Path, str] = ""
+    colinfo: Union[Path, str] = ""
+    colinphifom: Union[Path, str] = ""
+    colinfc: Union[Path, str] = ""
+    colinfree: Union[Path, str] = ""
     em: bool = False
     cycles: int = 3
     remove_clashing_protein: bool = True
@@ -33,8 +33,8 @@ class InputParameters:
 
 @dataclasses.dataclass
 class OutputParameters:
-    pdbout: str | Path = ""
-    xmlout: str | Path = ""
+    pdbout: Union[Path, str] = ""
+    xmlout: Union[Path, str] = ""
 
 
 def find_database() -> str:

--- a/package/src/nucleofind/build.py
+++ b/package/src/nucleofind/build.py
@@ -43,7 +43,11 @@ def find_database() -> str:
         if database_path.exists():
             return str(database_path)
 
-    clibd = os.environ.get("CLIBD", "")
+    clibd = os.environ.get("CLIBD")
+    if not clibd:
+        raise RuntimeError("Could not find the NucleoFind database in site-packages or the CCP4 installation."
+                           " Please install NucleoFind using the install command.")
+
     database_path = Path(clibd)  / "nucleofind_models" / "nucleofind-database.cif"
     if database_path.exists():
         return str(database_path)

--- a/package/src/nucleofind/install.py
+++ b/package/src/nucleofind/install.py
@@ -46,6 +46,7 @@ def install_model(type: model.ModelType, location: str, reinstall: bool) -> bool
             return False
 
         model.download_model(type=type, folder=clibd, reinstall=reinstall)
+        download_database(folder=clibd, reinstall=reinstall)
         return True
 
     if InstallLocation[location] == InstallLocation.site_packages:

--- a/package/src/nucleofind/prediction/arguments.py
+++ b/package/src/nucleofind/prediction/arguments.py
@@ -46,10 +46,10 @@ def parse_arguments() -> SimpleNamespace:
         type=int,
     )
     parser.add_argument(
-        "--use-symmetry",
+        "--use-asu-only",
         action=argparse.BooleanOptionalAction,
         default=False,
-        help="Compute predictions for the entire unit cell",
+        help="Compute predictions for only the Asymmetric Unit",
     )
     parser.add_argument(
         "--variance", action=argparse.BooleanOptionalAction, help="Output variance map"

--- a/package/src/nucleofind/prediction/config.py
+++ b/package/src/nucleofind/prediction/config.py
@@ -1,5 +1,6 @@
 import dataclasses
 import enum
+from typing import Optional
 
 
 @dataclasses.dataclass
@@ -7,7 +8,7 @@ class Configuration:
     """Configuration for NucleoFind"""
 
     use_gpu: bool = False
-    n_threads: int | None = None
+    n_threads: Optional[int] = None
     disable_progress_bar: bool = True
     compute_entire_unit_cell: bool = True
     compute_variance: bool = False

--- a/package/src/nucleofind/prediction/load.py
+++ b/package/src/nucleofind/prediction/load.py
@@ -6,12 +6,13 @@ from .util import find_map_coefficients, check_density_path
 import onnxruntime as rt
 import sys
 import logging
+from typing import Optional, Union
 
 
 def load_mtz(
-    path: Path | str,
-    column_names: List[str] | None,
-    resolution_cutoff: float | None,
+    path: Union[Path, str],
+    column_names: Optional[List[str]],
+    resolution_cutoff: Optional[float],
 ) -> gemmi.FloatGrid:
     """Load MTZ file and transform to map with 0.7A grid spacing and with resolution cutoff if specified."""
     mtz = gemmi.read_mtz_file(str(path))
@@ -32,7 +33,7 @@ def load_mtz(
     return grid
 
 
-def load_map(path: Path | str) -> gemmi.FloatGrid:
+def load_map(path: Union[Path, str]) -> gemmi.FloatGrid:
     """Load map file and normalize"""
     map = gemmi.read_ccp4_map(str(path))
     grid = map.grid
@@ -41,9 +42,9 @@ def load_map(path: Path | str) -> gemmi.FloatGrid:
 
 
 def load_density(
-    density_path: Path | str,
-    column_names: List[str] | None,
-    resolution_cutoff: float | None,
+    density_path: Union[Path, str],
+    column_names: Optional[List[str]],
+    resolution_cutoff: Optional[float],
 ) -> gemmi.FloatGrid:
     """Load density from MTZ file, or map file"""
     density_path = check_density_path(density_path)
@@ -55,7 +56,7 @@ def load_density(
 
 
 def load_onnx_model(
-    model_path: Path | str, use_gpu: bool = True
+    model_path: Union[Path, str], use_gpu: bool = True
 ) -> rt.InferenceSession:
     """Load ONNX model from model_path"""
     providers = ["CPUExecutionProvider"]

--- a/package/src/nucleofind/prediction/model.py
+++ b/package/src/nucleofind/prediction/model.py
@@ -1,11 +1,13 @@
 import os
 import site
+from tkinter.constants import RAISED
+
 import sys
 import urllib
 from pathlib import Path
 import logging
 from types import SimpleNamespace
-from typing import Tuple, List
+from typing import Tuple, List, Union, Optional
 
 import requests
 from enum import Enum
@@ -180,7 +182,7 @@ def extract_model_names(models: List[Path]) -> List[str]:
     return model_names
 
 
-def find_model(model: ModelType | str | None) -> Path | None:
+def find_model(model: Union[ModelType, str, None]) -> Optional[Path]:
     """Search through site-packages and CCP4/lib/data for a potential model"""
     potential_models = find_all_potential_models()
     if not potential_models:
@@ -207,16 +209,14 @@ def find_model(model: ModelType | str | None) -> Path | None:
     sys.exit(1)
 
 
-def get_model_config(model_path: Path, overlap: int | None) -> SimpleNamespace:
+def get_model_config(model_path: Path, overlap: Optional[int]) -> SimpleNamespace:
     """Get model configuration from model type"""
     model_type = model_path.stem.removeprefix("nucleofind-")
     if model_type not in ModelType.__members__:
         raise RuntimeError(f"Invalid model type - {model_type}")
     model_type = ModelType[model_type]
-    match model_type:
-        case ModelType.nano:
-            return SimpleNamespace(box_size=128, overlap=64 if overlap is None else overlap)
-        case ModelType.core:
-            return SimpleNamespace(box_size=128, overlap=64 if overlap is None else overlap)
-        case _:
-            raise RuntimeError(f"Invalid model type - {model_type}")
+    if model_type == ModelType.nano:
+        return SimpleNamespace(box_size=128, overlap=64 if overlap is None else overlap)
+    if model_type == ModelType.core:
+        return SimpleNamespace(box_size=128, overlap=64 if overlap is None else overlap)
+    raise RuntimeError(f"Invalid model type - {model_type}")

--- a/package/src/nucleofind/prediction/model.py
+++ b/package/src/nucleofind/prediction/model.py
@@ -213,17 +213,6 @@ def get_model_config(model_path: Path, overlap: Optional[int]) -> SimpleNamespac
     if model_type not in ModelType.__members__:
         raise RuntimeError(f"Invalid model type - {model_type}")
     model_type = ModelType[model_type]
-    match model_type:
-        case ModelType.nano:
-            return SimpleNamespace(
-                box_size=128, overlap=64 if overlap is None else overlap
-            )
-        case ModelType.core:
-            return SimpleNamespace(
-                box_size=128, overlap=64 if overlap is None else overlap
-            )
-        case _:
-            raise RuntimeError(f"Invalid model type - {model_type}")
     if model_type == ModelType.nano:
         return SimpleNamespace(box_size=128, overlap=64 if overlap is None else overlap)
     if model_type == ModelType.core:

--- a/package/src/nucleofind/prediction/model.py
+++ b/package/src/nucleofind/prediction/model.py
@@ -5,7 +5,7 @@ import urllib
 from pathlib import Path
 import logging
 from types import SimpleNamespace
-from typing import Tuple, List
+from typing import Tuple, List, Union, Optional
 
 import requests
 from enum import Enum
@@ -21,9 +21,9 @@ from .errors import (
 
 class ModelType(Enum):
     """Types of NucleoFind Model available"""
-
     nano = 1
     core = 2
+
 
 
 def calculate_sha256(file_path: Path):
@@ -177,7 +177,7 @@ def extract_model_names(models: List[Path]) -> List[str]:
     return model_names
 
 
-def find_model(model: ModelType | str | None) -> Path | None:
+def find_model(model: Union[ModelType, str, None]) -> Optional[Path]:
     """Search through site-packages and CCP4/lib/data for a potential model"""
     potential_models = find_all_potential_models()
     if not potential_models:
@@ -204,20 +204,18 @@ def find_model(model: ModelType | str | None) -> Path | None:
     sys.exit(1)
 
 
-def get_model_config(model_path: Path, overlap: int | None) -> SimpleNamespace:
+def get_model_config(model_path: Path, overlap: Optional[int]) -> SimpleNamespace:
     """Get model configuration from model type"""
     model_type = model_path.stem.removeprefix("nucleofind-")
     if model_type not in ModelType.__members__:
         raise RuntimeError(f"Invalid model type - {model_type}")
     model_type = ModelType[model_type]
-    match model_type:
-        case ModelType.nano:
-            return SimpleNamespace(
+    if model_type == ModelType.nano:
+        return SimpleNamespace(
                 box_size=128, overlap=64 if overlap is None else overlap
             )
-        case ModelType.core:
-            return SimpleNamespace(
+    if model_type == ModelType.core:
+        return SimpleNamespace(
                 box_size=128, overlap=64 if overlap is None else overlap
             )
-        case _:
-            raise RuntimeError(f"Invalid model type - {model_type}")
+    raise RuntimeError(f"Invalid model type - {model_type}")

--- a/package/src/nucleofind/prediction/predict.py
+++ b/package/src/nucleofind/prediction/predict.py
@@ -2,7 +2,7 @@ import functools
 import logging
 from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Tuple, Union, Optional
 import numpy as np
 from tqdm import tqdm
 
@@ -16,7 +16,7 @@ from .config import Configuration, MapType
 
 
 class NucleoFind:
-    def __init__(self, model_path: Path | str, configuration: Configuration):
+    def __init__(self, model_path: Union[Path, str], configuration: Configuration):
         self.model_path = model_path
         self.configuration = configuration
 
@@ -114,9 +114,9 @@ class NucleoFind:
 
     def predict(
         self,
-        density_path: Path | str,
-        column_names: List[str] | List[None],
-        resolution_cutoff: float | None = None,
+        density_path: Union[Path, str],
+        column_names: Optional[List[str]],
+        resolution_cutoff: Optional[float] = None,
     ):
         """Run a nucleofind prediction on specified density file. If density file is an MTZ, supply column names and an
         optional resolution cutoff. If density file is a MAP, these will be ignored."""
@@ -141,7 +141,7 @@ class NucleoFind:
             )
             self.predicted_grids[MapType(i)] = interpolated_index_array
 
-    def save_grid(self, type: MapType, output_path: Path | str):
+    def save_grid(self, type: MapType, output_path: Union[Path, str]):
         """Save the predicted grid to directory specified by output_path, with filename nucleofind-{type}.map."""
         output_path = Path(output_path)
         output_path.mkdir(exist_ok=True, parents=True)

--- a/package/src/nucleofind/prediction/predict.py
+++ b/package/src/nucleofind/prediction/predict.py
@@ -182,7 +182,7 @@ def run():
     configuration = Configuration(
         use_gpu=args.gpu,
         disable_progress_bar=args.silent,
-        compute_entire_unit_cell=False,
+        compute_entire_unit_cell=not args.use_asu_only,
         use_raw_values=args.raw,
         compute_variance=args.variance,
         n_threads=args.nthreads,

--- a/package/src/nucleofind/prediction/predict.py
+++ b/package/src/nucleofind/prediction/predict.py
@@ -2,7 +2,7 @@ import functools
 import logging
 from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Tuple, Union, Optional
 import numpy as np
 from tqdm import tqdm
 
@@ -16,7 +16,7 @@ from .config import Configuration, MapType
 
 
 class NucleoFind:
-    def __init__(self, model_path: Path | str, configuration: Configuration):
+    def __init__(self, model_path: Union[Path, str], configuration: Configuration):
         self.model_path = model_path
         self.configuration = configuration
 
@@ -123,9 +123,9 @@ class NucleoFind:
 
     def predict(
         self,
-        density_path: Path | str,
-        column_names: List[str] | List[None],
-        resolution_cutoff: float | None = None,
+        density_path: Union[Path, str],
+        column_names: Optional[List[str]],
+        resolution_cutoff: Optional[float] = None,
     ):
         """Run a nucleofind prediction on specified density file. If density file is an MTZ, supply column names and an
         optional resolution cutoff. If density file is a MAP, these will be ignored."""
@@ -150,7 +150,7 @@ class NucleoFind:
             )
             self.predicted_grids[MapType(i)] = interpolated_index_array
 
-    def save_grid(self, type: MapType, output_path: Path | str):
+    def save_grid(self, type: MapType, output_path: Union[Path, str]):
         """Save the predicted grid to directory specified by output_path, with filename nucleofind-{type}.map."""
         output_path = Path(output_path)
         output_path.mkdir(exist_ok=True, parents=True)

--- a/package/src/nucleofind/prediction/save.py
+++ b/package/src/nucleofind/prediction/save.py
@@ -1,8 +1,10 @@
+from typing import Union
+
 import gemmi
 from pathlib import Path
 
 
-def save_grid(grid: gemmi.FloatGrid, path: Path | str):
+def save_grid(grid: gemmi.FloatGrid, path: Union[Path, str]):
     """Save grid to CCP4 map file."""
     map = gemmi.Ccp4Map()
     map.grid = grid

--- a/package/tests/conftest.py
+++ b/package/tests/conftest.py
@@ -4,17 +4,25 @@ def pytest_addoption(parser):
     parser.addoption(
         "--runslow", action="store_true", default=False, help="run slow tests"
     )
+    parser.addoption(
+        "--ccp4", action="store_true", default=False, help="run CCP4 only tests"
+    )
 
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow to run")
+    config.addinivalue_line("markers", "ccp4: mark test as for CCP4 only")
 
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption("--runslow"):
-        # --runslow given in cli: do not skip slow tests
-        return
-    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
-    for item in items:
-        if "slow" in item.keywords:
-            item.add_marker(skip_slow)
+    if not config.getoption("--runslow"):
+        skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+        for item in items:
+            if "slow" in item.keywords:
+                item.add_marker(skip_slow)
+
+    if not config.getoption("--ccp4"):
+        skip_ccp4 = pytest.mark.skip(reason="need --ccp4 option to run")
+        for item in items:
+            if "ccp4" in item.keywords:
+                item.add_marker(skip_ccp4)

--- a/package/tests/test_building.py
+++ b/package/tests/test_building.py
@@ -42,7 +42,7 @@ def test_example(request):
 
 
 @pytest.fixture(scope='session')
-def parameters(data_base_path, test_example):
+def parameters(data_base_path, test_example, request):
     input = nucleofind_build.InputParameters()
     data_dir = data_base_path / test_example
     input.mtzin = data_dir / "hklout.mtz"
@@ -59,9 +59,10 @@ def parameters(data_base_path, test_example):
     input.colinfc = "FWT,PHWT"
     input.colinfree = "FREE"
 
-    os.environ["CLIBD"] = str(data_base_path)
-    os.environ["LD_LIBRARY_PATH"] = str(data_base_path)
-    os.environ["CCP4"] = str(data_base_path)
+    if not request.config.getoption("--ccp4"):
+        os.environ["CLIBD"] = str(data_base_path)
+        os.environ["LD_LIBRARY_PATH"] = str(data_base_path)
+        os.environ["CCP4"] = str(data_base_path)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir = Path(tmpdir)

--- a/package/tests/test_prediction.py
+++ b/package/tests/test_prediction.py
@@ -101,7 +101,7 @@ def predictions_cmdline_asu(parameters) -> Path:
         str: The path to the output file.
     """
     output = parameters.output.parent / ("cmd_" + parameters.output.stem)
-    cmd = f'nucleofind -i "{parameters.mtzin}" -o "{output}" -m {parameters.model_name} --use-asu-only -n 4'
+    cmd = f'nucleofind -i "{parameters.mtzin}" -o "{output}" -m {parameters.model_name} --use-asu-only'
     os.system(cmd)
     return output
 
@@ -118,13 +118,13 @@ def predictions_cmdline_unit_cell(parameters) -> Path:
         str: The path to the output file.
     """
     output = parameters.output.parent / ("cmd_" + parameters.output.stem)
-    cmd = f'nucleofind -i "{parameters.mtzin}" -o "{output}" -m {parameters.model_name} -n 4'
+    cmd = f'nucleofind -i "{parameters.mtzin}" -o "{output}" -m {parameters.model_name}'
     os.system(cmd)
     return output
 
 
 
-def test_python_prediction(predictions_python, parameters, expected_md5sums):
+def test_python_prediction(predictions_python, parameters, expected_md5sums_asu):
     """
     This function is used to test the predictions made by a Python model. It compares the MD5 sums of the predictions
     to the known MD5 sums.
@@ -137,7 +137,7 @@ def test_python_prediction(predictions_python, parameters, expected_md5sums):
     Raises:
         AssertionError: An error occurs if the calculated prediction MD5 sums do not equal the known MD5 sums.
     """
-    compare_sums(expected_md5sums, parameters, predictions_python)
+    compare_sums(expected_md5sums_asu, parameters, predictions_python)
 
 
 def test_cmdline_prediction_asu(predictions_cmdline_asu, parameters, expected_md5sums_asu):

--- a/package/tests/test_prediction.py
+++ b/package/tests/test_prediction.py
@@ -16,7 +16,7 @@ def data_base_path():
 
 
 @pytest.fixture(scope='session')
-def expected_md5sums(model_type):
+def expected_md5sums_asu(model_type):
     data = {
         "nano": SimpleNamespace(
             phosphate = "615b7f3ee576dd19f2cd3ffc762013ff",
@@ -30,6 +30,24 @@ def expected_md5sums(model_type):
         )
     }
     return data[model_type]
+
+@pytest.fixture(scope='session')
+def expected_md5sums_unit_cell(model_type):
+    data = {
+        "nano": SimpleNamespace(
+            phosphate = "7433e3929ccd6ba285bcdf2a02e0e569",
+            sugar = "bde3684708bc8bce76435b1035b2f506",
+            base = "19ea6321ff6bfe8229c0e806d312ae5a"
+        ),
+        "core": SimpleNamespace(
+            phosphate = "4ad09e5f26787d3e631539cc5d2e7e53",
+            sugar = "24c3758107b9e17ed07dd3cee57f49fb",
+            base = "d3a02b665db00be3e6bbcaec0874d7e8"
+        )
+    }
+    return data[model_type]
+
+
 
 def pytest_generate_tests(metafunc):
     """Generate model matrix with runslow option"""
@@ -72,9 +90,9 @@ def predictions_python(parameters) -> Path:
 
 
 @pytest.fixture(scope='session')
-def predictions_cmdline(parameters) -> Path:
+def predictions_cmdline_asu(parameters) -> Path:
     """
-    Run NucleoFind using the command line interface.
+    Run NucleoFind using the command line interface with only the ASU.
 
     Args:
         parameters (SimpleNamespace): A dictionary containing the necessary input parameters.
@@ -83,9 +101,27 @@ def predictions_cmdline(parameters) -> Path:
         str: The path to the output file.
     """
     output = parameters.output.parent / ("cmd_" + parameters.output.stem)
-    cmd = f'nucleofind -i "{parameters.mtzin}" -o "{output}" -m {parameters.model_name} --no-use-symmetry'
+    cmd = f'nucleofind -i "{parameters.mtzin}" -o "{output}" -m {parameters.model_name} --use-asu-only -n 4'
     os.system(cmd)
     return output
+
+
+@pytest.fixture(scope='session')
+def predictions_cmdline_unit_cell(parameters) -> Path:
+    """
+    Run NucleoFind using the command line interface with the unit cell.
+
+    Args:
+        parameters (SimpleNamespace): A dictionary containing the necessary input parameters.
+
+    Returns:
+        str: The path to the output file.
+    """
+    output = parameters.output.parent / ("cmd_" + parameters.output.stem)
+    cmd = f'nucleofind -i "{parameters.mtzin}" -o "{output}" -m {parameters.model_name} -n 4'
+    os.system(cmd)
+    return output
+
 
 
 def test_python_prediction(predictions_python, parameters, expected_md5sums):
@@ -104,10 +140,10 @@ def test_python_prediction(predictions_python, parameters, expected_md5sums):
     compare_sums(expected_md5sums, parameters, predictions_python)
 
 
-def test_cmdline_prediction(predictions_cmdline, parameters, expected_md5sums):
+def test_cmdline_prediction_asu(predictions_cmdline_asu, parameters, expected_md5sums_asu):
     """
-    This function is used to test the predictions made by a command line interface. It compares the MD5 sums of the
-    predictions to the known MD5 sums.
+    This function is used to test the predictions made by a command line interface with only the ASU. It compares the
+    MD5 sums of the predictions to the known MD5 sums.
 
     Parameters:
     - predictions_python (path): Path to the output model base directory.
@@ -117,7 +153,23 @@ def test_cmdline_prediction(predictions_cmdline, parameters, expected_md5sums):
     Raises:
         AssertionError: An error occurs if the calculated prediction MD5 sums do not equal the known MD5 sums.
        """
-    compare_sums(expected_md5sums, parameters, predictions_cmdline)
+    compare_sums(expected_md5sums_asu, parameters, predictions_cmdline_asu)
+
+def test_cmdline_prediction_unit_cell(predictions_cmdline_unit_cell, parameters, expected_md5sums_unit_cell):
+    """
+    This function is used to test the predictions made by a command line interface with only the ASU. It compares the
+    MD5 sums of the predictions to the known MD5 sums.
+
+    Parameters:
+    - predictions_python (path): Path to the output model base directory.
+    - parameters (SimpleNamespace): A dictionary of parameters used in the predictions.
+    - md5sums (SimpleNamespace): A dictionary of MD5 sums corresponding to the predictions.
+
+    Raises:
+        AssertionError: An error occurs if the calculated prediction MD5 sums do not equal the known MD5 sums.
+       """
+    compare_sums(expected_md5sums_unit_cell, parameters, predictions_cmdline_unit_cell)
+
 
 
 def compare_sums(md5sums, parameters, base_path):

--- a/package/tests/test_resources_available.py
+++ b/package/tests/test_resources_available.py
@@ -1,0 +1,61 @@
+import os
+import hashlib
+from pathlib import Path
+
+import pytest
+
+def get_md5_sums():
+    core_md5sum = "a843baa5eb38e2ced9298177771d44d3"
+    database_md5sum = "5e1e8b980b2359e74e1c9151780af926"
+
+    return {
+        "core": core_md5sum,
+        "database": database_md5sum,
+    }
+
+
+
+def calculate_md5_hash(file_path: str) -> str:
+    with open(file_path, "rb") as f:
+        file_hash = hashlib.md5()
+        while chunk := f.read(8192):
+            file_hash.update(chunk)
+
+        found_sum = file_hash.hexdigest()
+    return found_sum
+
+@pytest.mark.ccp4
+def test_files_intact():
+    data = get_md5_sums()
+
+    clibd = os.environ.get("CLIBD", "")
+    assert clibd != "", "Could not find CLIBD environment variable"
+
+    nucleofind_model_folder_path = Path(clibd) / "nucleofind_models"
+    assert nucleofind_model_folder_path.exists(), "Could not find nucleofind_models folder in CLIBD"
+
+    onnx_model_path = nucleofind_model_folder_path / f"nucleofind-core.onnx"
+    assert onnx_model_path.exists(), f"Could not find nucleofind-core.onnx model in nucleofind_models folder"
+
+    onnx_model_sum = calculate_md5_hash(str(onnx_model_path))
+    assert onnx_model_sum == data["core"], f"Model checksum mismatch for {onnx_model_path}"
+
+    database_path = nucleofind_model_folder_path / "nucleofind-database.cif"
+    assert database_path.exists(), f"Could not find nucleofind-database.cif in nucleofind_models folder"
+
+    database_sum = calculate_md5_hash(str(database_path))
+    assert database_sum == data["database"], f"Database checksum mismatch for {database_path}"
+
+@pytest.mark.ccp4
+def test_files_present():
+    clibd = os.environ.get("CLIBD", "")
+    assert clibd != "", "Could not find CLIBD environment variable"
+
+    nucleofind_model_folder_path = Path(clibd) / "nucleofind_models"
+    assert nucleofind_model_folder_path.exists(), "Could not find nucleofind_models folder in CLIBD"
+
+    onnx_model_path = nucleofind_model_folder_path / f"nucleofind-core.onnx"
+    assert onnx_model_path.exists(), f"Could not find nucleofind-core.onnx model in nucleofind_models folder"
+
+
+


### PR DESCRIPTION
## Description

This PR reduces the Python requirement from 3.10 to 3.9 for compatibility with CCP4. 

Also, this PR adds other CCP4 specific options and updates.  